### PR TITLE
Start work on testing state machine sagas

### DIFF
--- a/example/jest.config.js
+++ b/example/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   },
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  setupFiles: ['./setupJest.js'],
 };

--- a/example/package.json
+++ b/example/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "tslint --fix -c tslint.json 'src/**/*.ts'"
   },
   "devDependencies": {
+    "@types/lolex": "^2.1.3",
     "@types/react": "16.4.11",
     "@types/react-dom": "16.0.7",
     "@types/react-redux": "6.0.6",
@@ -21,9 +22,11 @@
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
+    "bluebird": "3.5.1",
     "jest": "23.5.0",
     "jest-cli": "23.5.0",
     "jest-junit": "5.1.0",
+    "lolex": "2.7.1",
     "prettier": "1.14.2",
     "react-hot-loader": "4.3.4",
     "string-hash": "^1.1.3",

--- a/example/setupJest.js
+++ b/example/setupJest.js
@@ -1,0 +1,4 @@
+Promise = require('bluebird');
+Promise.setScheduler((fn) => {
+  setImmediate(fn);
+});

--- a/example/src/player.test.ts
+++ b/example/src/player.test.ts
@@ -1,13 +1,63 @@
 import * as fs from 'fs';
+import * as lolex from 'lolex';
 import * as path from 'path';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { createStateMachineSaga } from 'redux-saga-state-machine';
 import { xstateToSvg } from '../../xstate-to-svg/dist';
-import { stateMachine } from './player';
+import {
+  actions,
+  reducer,
+  reducerKey,
+  selectors,
+  stateMachine,
+  states,
+} from './player';
 
 describe('state machine', () => {
   it('generate visualisation', () => {
     const svg = xstateToSvg(stateMachine);
     fs.writeFileSync(path.resolve(__dirname, 'player.svg'), svg, {
       encoding: 'utf8',
+    });
+  });
+
+  describe('saga', () => {
+    let clock;
+    beforeEach(() => {
+      clock = lolex.install();
+    });
+
+    afterEach(() => {
+      clock.uninstall();
+    });
+
+    it('runs', () => {
+      const sagaMiddleware = createSagaMiddleware();
+      const store = createStore(
+        combineReducers({ [reducerKey]: reducer }),
+        undefined,
+        applyMiddleware(sagaMiddleware),
+      );
+
+      const saga = createStateMachineSaga(stateMachine);
+
+      sagaMiddleware.run(saga, {
+        getState: store.getState,
+        dispatch: store.dispatch,
+      });
+
+      store.dispatch(actions.play());
+
+      expect(selectors.selectCurrentState(store.getState())).toEqual(
+        states.PLAYING,
+      );
+
+      store.dispatch(actions.stop());
+
+      expect(selectors.selectCurrentState(store.getState())).toEqual(
+        states.APP,
+      );
     });
   });
 });

--- a/example/src/player.ts
+++ b/example/src/player.ts
@@ -3,7 +3,7 @@ import { put } from 'redux-saga/effects';
 
 export const reducerKey = 'player';
 
-const states = {
+export const states = {
   APP: 'APP',
   PLAYING: 'PLAYING',
   SWITCHING: 'SWITCHING',

--- a/example/src/trafficLights.test.ts
+++ b/example/src/trafficLights.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as lolex from 'lolex';
 import * as path from 'path';
 import { applyMiddleware, combineReducers, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
@@ -13,20 +14,27 @@ import {
   states,
 } from './trafficLights';
 
-const wait = (duration) =>
-  new Promise((resolve) => setTimeout(() => resolve(), duration));
-
 describe('state machine', () => {
-  it('generate visualisation', () => {
-    const svg = xstateToSvg(stateMachine);
-    fs.writeFileSync(path.resolve(__dirname, 'trafficLights.svg'), svg, {
-      encoding: 'utf8',
+  describe('visualisation', () => {
+    it('generates svg', () => {
+      const svg = xstateToSvg(stateMachine);
+      fs.writeFileSync(path.resolve(__dirname, 'trafficLights.svg'), svg, {
+        encoding: 'utf8',
+      });
     });
   });
 
-  it(
-    'runs saga',
-    async () => {
+  describe('saga', () => {
+    let clock;
+    beforeEach(() => {
+      clock = lolex.install();
+    });
+
+    afterEach(() => {
+      clock.uninstall();
+    });
+
+    it('runs', () => {
       const sagaMiddleware = createSagaMiddleware();
       const store = createStore(
         combineReducers({ [reducerKey]: reducer }),
@@ -45,12 +53,25 @@ describe('state machine', () => {
         states.GREEN,
       );
 
-      // We should really be using a mock timer so we can run this test instantly
-      await wait(6000);
+      clock.tick(6001);
       expect(selectors.selectCurrentState(store.getState())).toEqual(
         states.YELLOW,
       );
-    },
-    7000,
-  );
+
+      clock.tick(6001);
+      expect(selectors.selectCurrentState(store.getState())).toEqual({
+        [states.RED]: states.WALK,
+      });
+
+      clock.tick(2501);
+      expect(selectors.selectCurrentState(store.getState())).toEqual({
+        [states.RED]: states.WAIT,
+      });
+
+      clock.tick(6001 - 2501);
+      expect(selectors.selectCurrentState(store.getState())).toEqual(
+        states.GREEN,
+      );
+    });
+  });
 });

--- a/example/src/trafficLights.test.ts
+++ b/example/src/trafficLights.test.ts
@@ -1,7 +1,20 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { createStateMachineSaga } from 'redux-saga-state-machine';
 import { xstateToSvg } from '../../xstate-to-svg/dist';
-import { stateMachine } from './trafficLights';
+import {
+  actions,
+  reducer,
+  reducerKey,
+  selectors,
+  stateMachine,
+  states,
+} from './trafficLights';
+
+const wait = (duration) =>
+  new Promise((resolve) => setTimeout(() => resolve(), duration));
 
 describe('state machine', () => {
   it('generate visualisation', () => {
@@ -10,4 +23,34 @@ describe('state machine', () => {
       encoding: 'utf8',
     });
   });
+
+  it(
+    'runs saga',
+    async () => {
+      const sagaMiddleware = createSagaMiddleware();
+      const store = createStore(
+        combineReducers({ [reducerKey]: reducer }),
+        undefined,
+        applyMiddleware(sagaMiddleware),
+      );
+
+      const saga = createStateMachineSaga(stateMachine);
+
+      sagaMiddleware.run(saga, {
+        getState: store.getState,
+        dispatch: store.dispatch,
+      });
+
+      expect(selectors.selectCurrentState(store.getState())).toEqual(
+        states.GREEN,
+      );
+
+      // We should really be using a mock timer so we can run this test instantly
+      await wait(6000);
+      expect(selectors.selectCurrentState(store.getState())).toEqual(
+        states.YELLOW,
+      );
+    },
+    7000,
+  );
 });

--- a/example/src/trafficLights.ts
+++ b/example/src/trafficLights.ts
@@ -3,7 +3,7 @@ import { put } from 'redux-saga/effects';
 
 export const reducerKey = 'trafficLights';
 
-const states = {
+export const states = {
   GREEN: 'GREEN',
   YELLOW: 'YELLOW',
   RED: 'RED',

--- a/redux-saga-state-machine/src/index.ts
+++ b/redux-saga-state-machine/src/index.ts
@@ -45,7 +45,7 @@ export const createStateMachineSaga = (
   }): SagaIterator {
     const activities: any[] = [];
 
-    const runActions = function*(result: any) {
+    const runActions = function*(result: any, event: any) {
       for (const action of result.actions as any[]) {
         if (action.type === 'xstate.start') {
           logger({
@@ -69,6 +69,7 @@ export const createStateMachineSaga = (
             label: `Action ${action.name}`,
             action,
             state,
+            event,
           });
           action({ getState, dispatch }, event);
         }
@@ -93,7 +94,7 @@ export const createStateMachineSaga = (
       initial,
     });
     yield put(setState(state));
-    yield* runActions(initial);
+    yield* runActions(initial, {});
 
     while (true) {
       const stateNodes = machine.getStateNodes(state);
@@ -130,7 +131,7 @@ export const createStateMachineSaga = (
         result,
       });
       yield put(setState(state));
-      yield* runActions(result);
+      yield* runActions(result, event);
     }
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4792,7 +4792,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
-kuker-emitters@^6.7.4:
+kuker-emitters@6.7.4:
   version "6.7.4"
   resolved "https://registry.yarnpkg.com/kuker-emitters/-/kuker-emitters-6.7.4.tgz#1fef1efbb75af05dd72846989cf401839e1f175b"
   dependencies:
@@ -7098,7 +7098,7 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
 
-string-hash@^1.1.3:
+string-hash@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,6 +563,10 @@
   version "23.3.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.1.tgz#a4319aedb071d478e6f407d1c4578ec8156829cf"
 
+"@types/lolex@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@types/lolex/-/lolex-2.1.3.tgz#793557c9b8ad319b4c8e4c6548b90893f4aa5f69"
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1762,7 +1766,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.5.1:
+bluebird@3.5.1, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -4792,7 +4796,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
-kuker-emitters@6.7.4:
+kuker-emitters@^6.7.4:
   version "6.7.4"
   resolved "https://registry.yarnpkg.com/kuker-emitters/-/kuker-emitters-6.7.4.tgz#1fef1efbb75af05dd72846989cf401839e1f175b"
   dependencies:
@@ -4929,6 +4933,10 @@ loglevelnext@^1.0.1:
   dependencies:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
+
+lolex@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.1.tgz#e40a8c4d1f14b536aa03e42a537c7adbaf0c20be"
 
 long@4.0.0:
   version "4.0.0"
@@ -7098,7 +7106,7 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
 
-string-hash@1.1.3:
+string-hash@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
 


### PR DESCRIPTION
I had a quick go at using `redux-saga-test-plan` but it didn't play well with sagas that use `delay`.

So I've started playing around with my own approach to testing sagas combined with reducers. Not much to show yet, but I'll add more to this PR when I have time.

Aims:
- Run sagas combined with reducers (so more like integration tests than unit tests).
- Use mock time/date (probably from `lolex`) to ensure we can run tests instantly.
- Treat the saga as a black box, only assert on the state of the store and dispatched actions. This means we'll probably need some way of spying on dispatched actions, possibly some store middleware?

I have a sneaking suspicion that as I do more work on this it will start to resemble `redux-saga-test-plan` more and more. If so then it should be easy to move across to it, and I'll have a better idea why it is the built the way it is.