### PR TITLE
Fix Netlify

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.11.0",
-  "npmClient": "yarn",
+  "npmClient": "npm",
   "useWorkspaces": true,
   "version": "0.6.0"
 }

--- a/redux-saga-state-machine/package.json
+++ b/redux-saga-state-machine/package.json
@@ -8,7 +8,7 @@
   "author": "Karl O'Keeffe <github@monket.net>",
   "license": "MIT",
   "scripts": {
-    "build": "yarn run lint && tsc",
+    "build": "npm run lint && tsc",
     "start": "tsc --watch",
     "test": "jest",
     "test:ci": "jest --ci --runInBand --reporters='default' --reporters='jest-junit'",

--- a/xstate-to-svg/package.json
+++ b/xstate-to-svg/package.json
@@ -8,7 +8,7 @@
   "author": "Karl O'Keeffe <github@monket.net>",
   "license": "MIT",
   "scripts": {
-    "build": "yarn run lint && tsc",
+    "build": "npm run lint && tsc",
     "start": "tsc --watch",
     "test": "jest",
     "test:ci": "jest --ci --runInBand --reporters='default' --reporters='jest-junit'",


### PR DESCRIPTION
Netlify has a bug where when building from the cache if you (or Lerna) calls Yarn from an npm script the wrong version of Yarn will be used.

I've had to work around this by having Lerna and scripts use npm instead. This isn't so bad as Yarn workspaces are still managing all the dependency installations.